### PR TITLE
waffle.io Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Stories in Ready](https://badge.waffle.io/3a-classic/score-api-server.png?label=ready&title=Ready)](https://waffle.io/3a-classic/score-api-server)
 # 3a-classic-server
 
 [![Circle CI](https://circleci.com/gh/3a-classic/score-api-server.svg?style=shield&circle-token=05ab242168e17f5fd1b442f85002417e6e963a3a)](https://circleci.com/gh/3a-classic/score-api-server)


### PR DESCRIPTION
Merge this to receive a badge indicating the number of issues in the ready column on your waffle.io board at https://waffle.io/3a-classic/score-api-server

This was requested by a real person (user sadayuki-matsuno) on waffle.io, we're not trying to spam you.
